### PR TITLE
调整默认js插件目录；去掉log函数前缀

### DIFF
--- a/src/PFJSR/Console.fs
+++ b/src/PFJSR/Console.fs
@@ -7,3 +7,5 @@ module Console=
         ("[PFJSR]",System.Drawing.Color.Yellow)|>Colorful.Console.Write
         ("[ERROR]",System.Drawing.Color.Red)|>Colorful.Console.Write
         printfn "%s" content
+    let log(content:string)=
+        (System.Console.WriteLine(content))

--- a/src/PFJSR/Data.fs
+++ b/src/PFJSR/Data.fs
@@ -12,7 +12,7 @@ module Data=
         member this.Path with get() =_Path and set value  =_Path<-value
     type ConfigJSRModel() = 
         let mutable _Enable : bool  = true
-        let mutable _Path : string  = "NetJS"
+        let mutable _Path : string  = "PFJS"
         member this.Enable with get() =_Enable and set value  =_Enable<-value
         member this.Path with get() =_Path and set value  =_Path<-value
     type ConfigModel() =

--- a/src/PFJSR/NetJS/nativefunc.fs
+++ b/src/PFJSR/NetJS/nativefunc.fs
@@ -11,7 +11,7 @@ module NativeFunc=
     module Basic=
         let shares  = new System.Collections.Generic.Dictionary<string,obj>()
         type log_delegate = delegate of string -> unit
-        let log=log_delegate(fun e-> Console.WriteLine(e))
+        let log=log_delegate(fun e-> Console.log(e))
         type fileReadAllText_delegate = delegate of string -> string
         let fileReadAllText=
             fileReadAllText_delegate (fun e->  


### PR DESCRIPTION
为避免和已有BDSJSR2插件冲突，建议更改默认js插件目录为其它目录。
用户可能会自拟打印格式，故去掉PFJSR前缀。